### PR TITLE
feat: Support runtime evaluated variables as values for css properties

### DIFF
--- a/examples/examples/basic/index.tsx
+++ b/examples/examples/basic/index.tsx
@@ -1,13 +1,14 @@
 import { css, cssVar } from "@brickss/compiler";
 const myVar = cssVar("my-font-size", "13px");
 const myVar2 = cssVar("my-font-size-2", "15px");
+const redColor = "red";
 
 const styles = css({
   background: "green",
   fontSize: myVar,
   lineHeight: myVar2,
   ".something": {
-    color: "red",
+    color: redColor,
     padding: "10px"
   },
   ".something[state|inverse]": {

--- a/packages/compiler/src/babel/transform.test.ts
+++ b/packages/compiler/src/babel/transform.test.ts
@@ -13,6 +13,7 @@ import { css as cs, cssVar } from "@brickss/compiler";
 const randomHeight = () => Math.random();
 const myVar = cssVar("my-font-size", "13px");
 const dynamicValueCssVar = cssVar("height", \`$\{randomHeight() * 100}px\`);
+const justAVar = "red";
 
 export const exportedCssVar = cssVar("my-font-size-2", "15px");
 
@@ -22,7 +23,7 @@ const styles = cs({
   lineHeight: exportedCssVar,
   height: dynamicValueCssVar,
   ".something": {
-    color: "red",
+    color: justAVar,
     padding: "10px"
   },
   ".something[state|inverse]": {

--- a/packages/compiler/src/common/print-styles.ts
+++ b/packages/compiler/src/common/print-styles.ts
@@ -5,13 +5,13 @@ import {
   isStyleDeclaration
 } from "./styles-compiler";
 
-export type PrintableValueCSSVar = {
-  type: "cssVar";
+export type PrintableValueIdentifier = {
+  type: "identifier";
   value: { name: string; identifier: string };
 };
 export type PrintableValue =
   | { type: "static"; value: string }
-  | PrintableValueCSSVar;
+  | PrintableValueIdentifier;
 
 export function printStyles(scope: RootScope) {
   let styles = scope.styles
@@ -71,7 +71,7 @@ export function printStyleDeclaration(
   styleDeclaration.properties.forEach(({ name, value }) => {
     if (value.type === "identifier") {
       style.push({
-        type: "cssVar",
+        type: "identifier",
         value: { name, identifier: value.value }
       });
     } else {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,2 +1,1 @@
-export { transform } from "./typescript/transform";
 export { css, cssVar } from "./compile-time-imports";

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -19,3 +19,9 @@ exports._os = function(state) {
   }
   return cls;
 };
+
+exports._id = function(n, v) {
+  return v && v.name && v.defaultValue
+    ? n + ":" + v.defaultValue + ";" + n + ":var(--" + v.name + ");"
+    : n + ":" + v + ";";
+};


### PR DESCRIPTION
Uncompressed check; limit: 2000
	✅ bytes: 577
Uncompressed gzip check; limit: 500
	✅ bytes: 321
Compressed gzip check; limit: 300
	✅ bytes: 263